### PR TITLE
allow to build on Raspberry pi

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,14 @@ libc = "0.2"
 atty = "0.1"
 libc = "0.2"
 
+[target.arm-unknown-linux-gnueabihf.dependencies]
+atty = "0.1"
+libc = "0.2"
+
+[target.armv7-unknown-linux-gnueabihf.dependencies]
+atty = "0.1"
+libc = "0.2"
+
 [target.x86_64-pc-windows-msvc.dependencies]
 winapi = "0.2"
 kernel32-sys = "0.2"


### PR DESCRIPTION
termsize fails to compile on a raspberry pi running raspbian, because it cannot find it's dependencies. This commits adds support for the targets `arm-unknown-linux-gnueabihf` and `armv7-unknown-linux-gnueabihf`.

I tested both targets on a Raspberry pi 2, the example program shows the correct terminal size, both using ssh, a x-windows terminal and a text terminal. 
