### PR TITLE
Add support for Fuchsia.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,14 @@ libc = "0.2"
 atty = "0.1"
 libc = "0.2"
 
+[target.x86_64-unknown-fuchsia.dependencies]
+atty = "0.1"
+libc = "0.2"
+
+[target.aarch64-unknown-fuchsia.dependencies]
+atty = "0.1"
+libc = "0.2"
+
 [target.x86_64-pc-windows-msvc.dependencies]
 winapi = "0.2"
 kernel32-sys = "0.2"


### PR DESCRIPTION
As some background, [Fuchsia](https://en.wikipedia.org/wiki/Google_Fuchsia) is a new operating system [under development](https://github.com/fuchsia-mirror) by Google. It is based on a new microkernel called [Magenta](https://github.com/fuchsia-mirror/magenta).

Sadly we cannot really test this in a faithful way since Fuchsia support is still ongoing in Rust.

ref https://github.com/uutils/coreutils/issues/999

cc @raphlinus