### PR TITLE
Add support for size in pixels when available

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,12 @@ pub struct Size {
     pub rows: u16,
     /// number of columns
     pub cols: u16,
+
+    /// width in pixels
+    pub width: Option<u16>,
+
+    /// height in pixels
+    pub height: Option<u16>,
 }
 
 #[cfg(unix)]

--- a/src/win.rs
+++ b/src/win.rs
@@ -34,6 +34,9 @@ pub fn get() -> Option<Size> {
         Size {
             rows: (inf.srWindow.Bottom - inf.srWindow.Top + 1) as u16,
             cols: (inf.srWindow.Right - inf.srWindow.Left + 1) as u16,
+
+            width: None,
+            height: None,
         }
     })
 }


### PR DESCRIPTION
Closes #6.

Note that this is a breaking change, since it adds public fields to the struct, so it should probably mean a minor version bump.

Also uses `winsize` from `libc` since it's available.