### PR TITLE
Use the UNIX interface for Redox

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,3 @@ libc = "0.2"
 [target.'cfg(windows)'.dependencies]
 winapi = "0.2"
 kernel32-sys = "0.2"
-
-[target.'cfg(target_os = "redox")'.dependencies]
-termion = "1.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,11 +31,6 @@ mod win;
 #[cfg(windows)]
 pub use self::win::get;
 
-#[cfg(target_os = "redox")]
-mod redox;
-#[cfg(target_os = "redox")]
-pub use self::redox::get;
-
 #[cfg(test)]
 mod tests {
     use super::get;

--- a/src/redox.rs
+++ b/src/redox.rs
@@ -1,8 +1,0 @@
-use self::super::Size;
-
-/// Gets the current terminal size
-pub fn get() -> Option<Size> {
-    termion::terminal_size().ok().map(|(cols, rows)| {
-        Size { rows, cols }
-    })
-}


### PR DESCRIPTION
Redox now has a proper libc, so use it instead of termion.