### PR TITLE
Add shim for unsupported platforms

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,14 +22,18 @@ pub struct Size {
 }
 
 #[cfg(unix)]
-mod nix;
-#[cfg(unix)]
-pub use self::nix::get;
+#[path = "nix.rs"]
+mod imp;
 
 #[cfg(windows)]
-mod win;
-#[cfg(windows)]
-pub use self::win::get;
+#[path = "win.rs"]
+mod imp;
+
+#[cfg(not(any(unix, windows)))]
+#[path = "other.rs"]
+mod imp;
+
+pub use imp::get;
 
 #[cfg(test)]
 mod tests {

--- a/src/other.rs
+++ b/src/other.rs
@@ -1,0 +1,4 @@
+/// Gets the current terminal size
+pub fn get() -> Option<super::Size> {
+	None
+}


### PR DESCRIPTION
This allows termsize and its dependencies to compile on other platforms without terminal API support (e.g. wasm32).