### PR TITLE
Bump winapi to 0.3 and remove kernel-sys crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,4 @@ atty = "0.2"
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
-winapi = "0.2"
-kernel32-sys = "0.2"
+winapi = { version = "0.3", features = ["handleapi"] }

--- a/src/win.rs
+++ b/src/win.rs
@@ -1,19 +1,25 @@
-use self::super::Size;
 use std::ptr;
+
+use winapi::um::{
+    fileapi::CreateFileA,
+    fileapi::OPEN_EXISTING,
+    handleapi::INVALID_HANDLE_VALUE,
+    wincon::{GetConsoleScreenBufferInfo, CONSOLE_SCREEN_BUFFER_INFO},
+    winnt::{FILE_SHARE_WRITE, GENERIC_READ, GENERIC_WRITE},
+};
+
+use self::super::Size;
 
 /// Gets the current terminal size
 pub fn get() -> Option<Size> {
     // http://rosettacode.org/wiki/Terminal_control/Dimensions#Windows
-    use self::kernel32::{self, GetConsoleScreenBufferInfo};
-    use self::winapi::{self, CONSOLE_SCREEN_BUFFER_INFO, HANDLE,
-                       INVALID_HANDLE_VALUE};
-    let handle: HANDLE = unsafe {
-        kernel32::CreateFileA(
+    let handle = unsafe {
+        CreateFileA(
             b"CONOUT$\0".as_ptr() as *const i8,
-            winapi::GENERIC_READ | winapi::GENERIC_WRITE,
-            winapi::FILE_SHARE_WRITE,
+            GENERIC_READ | GENERIC_WRITE,
+            FILE_SHARE_WRITE,
             ptr::null_mut(),
-            winapi::OPEN_EXISTING,
+            OPEN_EXISTING,
             0,
             ptr::null_mut(),
         )
@@ -23,17 +29,16 @@ pub fn get() -> Option<Size> {
     }
     let info = unsafe {
         // https://msdn.microsoft.com/en-us/library/windows/desktop/ms683171(v=vs.85).aspx
-        let mut info = ::std::mem::uninitialized();
-        if GetConsoleScreenBufferInfo(handle, &mut info) == 0 {
+        let mut info =
+            ::std::mem::MaybeUninit::<CONSOLE_SCREEN_BUFFER_INFO>::uninit();
+        if GetConsoleScreenBufferInfo(handle, info.as_mut_ptr()) == 0 {
             None
         } else {
-            Some(info)
+            Some(info.assume_init())
         }
     };
-    info.map(|inf| {
-        Size {
-            rows: (inf.srWindow.Bottom - inf.srWindow.Top + 1) as u16,
-            cols: (inf.srWindow.Right - inf.srWindow.Left + 1) as u16,
-        }
+    info.map(|inf| Size {
+        rows: (inf.srWindow.Bottom - inf.srWindow.Top + 1) as u16,
+        cols: (inf.srWindow.Right - inf.srWindow.Left + 1) as u16,
     })
 }


### PR DESCRIPTION
If you ever decides to merge this please consider releasing a new version. I am currently trying to fix an issue where winapi@0.2 was using code that Rust will no longer compile in the future.

Signed-off-by: Hanif Bin Ariffin <hanif.ariffin.4326@gmail.com>