### PR TITLE
Prevent the Unix implementation being optimised away in release mode

### DIFF
--- a/src/nix.rs
+++ b/src/nix.rs
@@ -23,13 +23,13 @@ pub fn get() -> Option<Size> {
     if atty::isnt(atty::Stream::Stdout) {
         return None;
     }
-    let us = UnixSize {
+    let mut us = UnixSize {
         rows: 0,
         cols: 0,
         x: 0,
         y: 0,
     };
-    let r = unsafe { ioctl(STDOUT_FILENO, TIOCGWINSZ.into(), &us) };
+    let r = unsafe { ioctl(STDOUT_FILENO, TIOCGWINSZ.into(), &mut us) };
     if r == 0 {
         Some(Size {
             rows: us.rows,


### PR DESCRIPTION
When building for release mode, the call to `ioctl` in the Unix implementation is being optimised away, and zero values are being returned. This is because the data output structure and the reference to it being passed to the `ioctl` syscall are not mutable.