### PR TITLE
Suggest removing atty dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ edition = "2021"
 #coveralls = { repository = "softprops/termsize" }
 
 [target.'cfg(unix)'.dependencies]
-atty = "0.2"
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["tty", "terminal", "term", "size", "dimensions"]
 license = "MIT"
 readme = "README.md"
 edition = "2021"
+rust-version = "1.70"
 
 #[badges]
 #travis-ci = { repository = "softprops/termsize" }

--- a/src/nix.rs
+++ b/src/nix.rs
@@ -1,8 +1,10 @@
 extern crate libc;
 
+use std::io::IsTerminal;
+
 use self::{
     super::Size,
-    libc::{c_ushort, ioctl, isatty, STDOUT_FILENO, TIOCGWINSZ},
+    libc::{c_ushort, ioctl, STDOUT_FILENO, TIOCGWINSZ},
 };
 
 /// A representation of the size of the current terminal
@@ -20,7 +22,7 @@ pub struct UnixSize {
 /// Gets the current terminal size
 pub fn get() -> Option<Size> {
     // http://rosettacode.org/wiki/Terminal_control/Dimensions#Library:_BSD_libc
-    if unsafe { isatty(STDOUT_FILENO) == 0 } {
+    if !std::io::stdout().is_terminal() {
         return None;
     }
     let mut us = UnixSize {

--- a/src/nix.rs
+++ b/src/nix.rs
@@ -1,9 +1,8 @@
-extern crate atty;
 extern crate libc;
 
 use self::{
     super::Size,
-    libc::{c_ushort, ioctl, STDOUT_FILENO, TIOCGWINSZ},
+    libc::{c_ushort, ioctl, isatty, STDOUT_FILENO, TIOCGWINSZ},
 };
 
 /// A representation of the size of the current terminal
@@ -21,7 +20,7 @@ pub struct UnixSize {
 /// Gets the current terminal size
 pub fn get() -> Option<Size> {
     // http://rosettacode.org/wiki/Terminal_control/Dimensions#Library:_BSD_libc
-    if atty::isnt(atty::Stream::Stdout) {
+    if unsafe { isatty(STDOUT_FILENO) == 0 } {
         return None;
     }
     let mut us = UnixSize {


### PR DESCRIPTION
atty is unmaintained and has outstanding sec advisory [RUSTSEC-2021-0145](https://rustsec.org/advisories/RUSTSEC-2021-0145).

https://github.com/softprops/atty/issues/50

As removal of the dependency is simple, this seems like the obvious solution.

Copied from the atty source here:
https://github.com/softprops/atty/blob/6633c0e1446aa19e6cd00e00e39770da43081bda/src/lib.rs#L40

This should be the exact equivalent but using libc directly.

Hope you don't mind the surprise PR @softprops... this just came up on `cargo deny` on an internal repo